### PR TITLE
Update DbUp to version 5.0.37 and appropriate override GetInsertScriptCommand

### DIFF
--- a/src/DbUp.Downgrade.PostgreSQL/DbUp.Downgrade.PostgreSQL.csproj
+++ b/src/DbUp.Downgrade.PostgreSQL/DbUp.Downgrade.PostgreSQL.csproj
@@ -3,17 +3,17 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Extends DbUp pipeline adding capability to store revert scripts in Schema Version table. In case that older version is found newer versions are rolled back. SchemaVersion implementation for PostgreSQL.</Description>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <Authors>Atanas Simeonov</Authors>
     <PackageProjectUrl>https://github.com/asimeonov/DbUp.Downgrade</PackageProjectUrl>
     <RepositoryUrl>https://github.com/asimeonov/DbUp.Downgrade</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
+    <AssemblyVersion>2.4.0.0</AssemblyVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-postgresql" Version="5.0.8" />
+    <PackageReference Include="dbup-postgresql" Version="5.0.37" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DbUp.Downgrade.SqlServer.Tests/DbUp.Downgrade.SqlServer.Tests.csproj
+++ b/src/DbUp.Downgrade.SqlServer.Tests/DbUp.Downgrade.SqlServer.Tests.csproj
@@ -68,7 +68,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
+    <!--<PackageReference Include="DbUp.Downgrade" Version="2.4.0" />-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/DbUp.Downgrade.SqlServer/DbUp.Downgrade.SqlServer.csproj
+++ b/src/DbUp.Downgrade.SqlServer/DbUp.Downgrade.SqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <Authors>Atanas Simeonov</Authors>
     <Company>Atanas Simeonov</Company>
     <Description>Extends DbUp pipeline adding capability to store revert scripts in Schema Version table. In case that older version is found newer versions are rolled back. SchemaVersion implementation for MS SqlServer.</Description>
@@ -11,12 +11,12 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DbUp.Downgrade</PackageId>
     <Product>DbUp.Downgrade</Product>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
+    <AssemblyVersion>2.4.0.0</AssemblyVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DbUp.Downgrade/DbUp.Downgrade.csproj
+++ b/src/DbUp.Downgrade/DbUp.Downgrade.csproj
@@ -6,17 +6,17 @@
     <PackageProjectUrl>https://github.com/asimeonov/DbUp.Downgrade</PackageProjectUrl>
     <RepositoryUrl>https://github.com/asimeonov/DbUp.Downgrade</RepositoryUrl>
     <RepositoryType />
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
+    <AssemblyVersion>2.4.0.0</AssemblyVersion>
     <Authors>Atanas Simeonov</Authors>
     <Company>Atanas Simeonov</Company>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <PackageId>DbUp.Downgrade.Core</PackageId>
     <Product>DbUp.Downgrade.Core</Product>
-    <FileVersion>2.3.0.0</FileVersion>
+    <FileVersion>2.4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-core" Version="5.0.10" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
   </ItemGroup>
 
 </Project>

--- a/src/DbUp.Downgrade/DowngradeEnabledTableJournal.cs
+++ b/src/DbUp.Downgrade/DowngradeEnabledTableJournal.cs
@@ -72,7 +72,7 @@ namespace DbUp.Downgrade
             });
         }
 
-        protected new IDbCommand GetInsertScriptCommand(Func<IDbCommand> dbCommandFactory, SqlScript script)
+        protected override IDbCommand GetInsertScriptCommand(Func<IDbCommand> dbCommandFactory, SqlScript script)
         {
             var command = dbCommandFactory();
 


### PR DESCRIPTION
DbUp now added virtual modifier to GetInsertScriptCommand allowing appropriate override instead of overriding the method with "new" keyword.